### PR TITLE
Adds DS_STore to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.DS_Store


### PR DESCRIPTION
## Issue 
What issue does this concern?

## Files Changes

- .gitignore
    - adds .DS_Store

## How to confirm that its working
- clone the repo
- open the .gitignore
- verify that you see .DS_Store

## Image
<img width="350" alt="Screenshot 2024-09-10 at 9 31 12 AM" src="https://github.com/user-attachments/assets/28bc1849-c92a-4c3e-ad42-f26f7609f6a5">
